### PR TITLE
Weather data/title bug

### DIFF
--- a/src/components/Result.jsx
+++ b/src/components/Result.jsx
@@ -171,7 +171,7 @@ const Events = ({data}) => {
 };
 
 const Weather = ({data, startDate, endDate}) => {
-  //console.log('WeatherDataInWeatherComponent: ', data);
+  //The weather header is sometimes not correct even if a single date is chosen
   const weatherHeader = JSON.stringify(startDate) != JSON.stringify(endDate) ? "Weather info for the next 5 days" : "Weather for the chosen day";
 	if (!data) {
 		return <p>No weather info available for this selection.</p>;


### PR DESCRIPTION
I chose December 5. as the date yet still got date from the 4. and the 5. 
![weatherAPIbuggedData](https://user-images.githubusercontent.com/44898491/70237108-b2ace600-1766-11ea-9a6e-feba11071170.PNG)
It is not shown in the image above but sometimes the title also says "Weather for the next 5 days" when a single date is chosen. There must be some bugs somewhere in the date picker component